### PR TITLE
Add ability to resume a training run from a checkpoint in wandb

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,13 @@ transforms: crop, crop-transpose
 
 ## Resuming a training run
 
-You can also continue training from a saved checkpoint using the `resume` command. This command assumes that you have a
-checkpoint saved as a Weights and Biases artifact. It will load the configuration from the run associated with the
-provided artifact, and then can optionally provide a set of overrides passed from the command line. Anything after the
-`--` is treated as a Hydra override command. You can use this to update certain configurations from the original run
-which you would like to change, such as training for more epochs.
+You can also continue training from a checkpoint saved in Weights and Biases using the `resume` command.
+This command assumes that you have a checkpoint saved as a Weights and Biases artifact. It will load the
+configuration from the run associated with the provided artifact, and then can optionally provide a set of
+overrides passed from the command line. Anything after the `--` is treated as a Hydra override command. You
+can use this to update certain configurations from the original run which you would like to change, such as
+training for more epochs.
 
 ```
-resume jeremytjordan/midi-language-modeling-test/model-bmpqj6ev:v2 -- trainer.max_epochs=20
+resume user/project/model:tag -- trainer.max_epochs=20
 ```

--- a/README.md
+++ b/README.md
@@ -100,30 +100,30 @@ dataclass objects. These dataclass objects are given short-names in the "config 
 Example local runs:
 ```
 train compute=local logger=wandb-test trainer=mps \
-    tokenizer=mmt model=mmt network=mmt-small \
+    tokenizer=mmt model=mmt network=mmt-1m \
     dataset=scales transforms=crop \
     trainer.val_check_interval=1.0 trainer.max_epochs=20
 ```
 ```
 train compute=local logger=wandb-test trainer=mps \
-    tokenizer=mmt model=mmt network=mmt-small \
+    tokenizer=mmt model=mmt network=mmt-1m \
     dataset=bach transforms=crop_transpose \
     trainer.val_check_interval=1.0
 ```
 ```
 train compute=local logger=wandb-test trainer=mps \
-    tokenizer=mmt model=mmt network=mmt-small \
+    tokenizer=mmt model=mmt network=mmt-1m \
     dataset=nes transforms=crop-transpose
 ```
 
 Example remote run:
 ```
 train compute=a10g compute.timeout=21600 logger=wandb trainer=gpu \
-    tokenizer=mmt model=mmt network=mmt \
+    tokenizer=mmt model=mmt network=mmt-7m \
     dataset=maestro transforms=crop-transpose
 
 train compute=a10g compute.timeout=3600 logger=wandb-test trainer=gpu \
-    tokenizer=mmt model=mmt network=mmt \
+    tokenizer=mmt model=mmt network=mmt-7m \
     dataset=nes transforms=crop-transpose \
     +trainer.profiler="simple" +trainer.max_steps=10
 ```
@@ -155,4 +155,16 @@ optimizer: adam, adamw, sgd
 tokenizer: mmt, structured, tpd
 trainer: cpu, gpu, mps, smoke-test
 transforms: crop, crop-transpose
+```
+
+## Resuming a training run
+
+You can also continue training from a saved checkpoint using the `resume` command. This command assumes that you have a
+checkpoint saved as a Weights and Biases artifact. It will load the configuration from the run associated with the
+provided artifact, and then can optionally provide a set of overrides passed from the command line. Anything after the
+`--` is treated as a Hydra override command. You can use this to update certain configurations from the original run
+which you would like to change, such as training for more epochs.
+
+```
+resume jeremytjordan/midi-language-modeling-test/model-bmpqj6ev:v2 -- trainer.max_epochs=20
 ```

--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ transforms: crop, crop-transpose
 You can also continue training from a checkpoint saved in Weights and Biases using the `resume` command.
 This command assumes that you have a checkpoint saved as a Weights and Biases artifact. It will load the
 configuration from the run associated with the provided artifact, and then can optionally provide a set of
-overrides passed from the command line. Anything after the `--` is treated as a Hydra override command. You
-can use this to update certain configurations from the original run which you would like to change, such as
-training for more epochs.
+overrides passed from the command line. Anything after the `--` (end of options delimiter) is treated as a
+Hydra override command. You can use this to update certain configurations from the original run which you
+would like to change, such as training for more epochs.
 
 ```
-resume user/project/model:tag -- trainer.max_epochs=20
+resume user/project/model:tag -- trainer.max_epochs=20 dataset.batch_size=32
 ```
 
 By default, much of the model and training state will be loaded from the checkpoint. This includes states

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ would like to change, such as training for more epochs.
 resume user/project/model:tag -- trainer.max_epochs=20 dataset.batch_size=32
 ```
 
-By default, much of the model and training state will be loaded from the checkpoint. This includes states
+By default, all of the model and training states **will** be loaded from the checkpoint. This includes states
 such as the optimizer and learning rate schedulers, as well as the current epoch and global step for the
-trainer. If you wish to resume training with a new learning rate, for example, you must include the `--clean`
+trainer. If you wish to resume training with a _new_ learning rate, for example, you must include the `--clean`
 flag. This will load the model weights from the specified checkpoint file, but all other states will be reset.
 
 ```

--- a/README.md
+++ b/README.md
@@ -169,3 +169,12 @@ training for more epochs.
 ```
 resume user/project/model:tag -- trainer.max_epochs=20
 ```
+
+By default, much of the model and training state will be loaded from the checkpoint. This includes states
+such as the optimizer and learning rate schedulers, as well as the current epoch and global step for the
+trainer. If you wish to resume training with a new learning rate, for example, you must include the `--clean`
+flag. This will load the model weights from the specified checkpoint file, but all other states will be reset.
+
+```
+resume user/project/model:tag --clean -- trainer.max_epochs=20
+```

--- a/midi_lm/config/__init__.py
+++ b/midi_lm/config/__init__.py
@@ -49,6 +49,7 @@ class TrainingConfig:
     tokenizer: Any = MISSING
     trainer: Any = MISSING
     transforms: Any = MISSING
+    resume_from_checkpoint: str | None = None
 
 
 config = ConfigStore.instance()

--- a/midi_lm/config/__init__.py
+++ b/midi_lm/config/__init__.py
@@ -49,7 +49,9 @@ class TrainingConfig:
     tokenizer: Any = MISSING
     trainer: Any = MISSING
     transforms: Any = MISSING
+    # optional configs for training runs which resume from a checkpoint
     resume_from_checkpoint: str | None = None
+    resume_from_clean_state: bool = False
 
 
 config = ConfigStore.instance()

--- a/midi_lm/config/lr_schedulers.py
+++ b/midi_lm/config/lr_schedulers.py
@@ -23,7 +23,7 @@ class ReduceLROnPlateauConfig:
 @dataclass
 class CosineAnnealingWarmRestarts:
     _target_: str = "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts"
-    T_0: int = 200
+    T_0: int = 2000
     T_mult: int = 2
     eta_min: float = 1e-6
 

--- a/midi_lm/config/optimizers.py
+++ b/midi_lm/config/optimizers.py
@@ -12,7 +12,7 @@ class AdamOptimizerConfig:
 class AdamWOptimizerConfig:
     _target_: str = "torch.optim.AdamW"
     lr: float = 0.002
-    weight_decay: float = 1e-2
+    weight_decay: float = 1e-3
 
 
 @dataclass

--- a/midi_lm/config/trainer.py
+++ b/midi_lm/config/trainer.py
@@ -9,7 +9,6 @@ class CpuDebugTrainerConfig:
     log_every_n_steps: int = 1
     overfit_batches: int = 1
     gradient_clip_val: float = 1.0
-    val_check_interval: int | float = 10
 
 
 @dataclass
@@ -20,7 +19,6 @@ class MpsTrainerConfig:
     accelerator: str = "mps"
     devices: int = 1
     gradient_clip_val: float = 1.0
-    val_check_interval: int | float = 150
 
 
 @dataclass
@@ -30,7 +28,6 @@ class CpuTrainerConfig:
     accelerator: str = "cpu"
     log_every_n_steps: int = 1
     gradient_clip_val: float = 1.0
-    val_check_interval: int | float = 150
 
 
 @dataclass
@@ -42,4 +39,3 @@ class GpuTrainerConfig:
     accelerator: str = "gpu"
     precision: str = "16-mixed"
     gradient_clip_val: float = 1.0
-    val_check_interval: int | float = 150

--- a/midi_lm/train.py
+++ b/midi_lm/train.py
@@ -3,6 +3,10 @@ from pathlib import Path
 
 import hydra
 import lightning.pytorch as pl
+import typer
+import wandb
+from hydra import compose, initialize_config_module
+from hydra.core.config_store import ConfigStore
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
 from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint, RichProgressBar
@@ -16,12 +20,23 @@ from midi_lm.config.transforms import create_transforms
 from midi_lm.modal_config import stub, train_a10g, train_a100, train_cpu
 from midi_lm.tokenizers import BaseTokenizer
 
+resume_cli = typer.Typer()
+
 
 # underlying training function
 def run_training(config: TrainingConfig):
     run_dir = HydraConfig.get().run.dir
     checkpoint_dir = Path(run_dir, "checkpoints")
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    # if we're resuming a training run, download the checkpoint artifact
+    if config.resume_from_checkpoint is not None:
+        api = wandb.Api()
+        model_checkpoint = api.artifact(config.resume_from_checkpoint)
+        model_checkpoint.download(root=checkpoint_dir.as_posix())
+        ckpt_path = Path(checkpoint_dir, "model.ckpt").as_posix()
+    else:
+        ckpt_path = None
 
     tokenizer: BaseTokenizer = hydra.utils.instantiate(config.tokenizer)
     collate_fn = hydra.utils.get_method(config.collator._target_)
@@ -61,7 +76,7 @@ def run_training(config: TrainingConfig):
 
     trainer: pl.Trainer = hydra.utils.instantiate(config.trainer, logger=logger, callbacks=callbacks)
     logger.log_hyperparams(OmegaConf.to_container(config))  # type: ignore
-    trainer.fit(model=model, datamodule=dataset)
+    trainer.fit(model=model, datamodule=dataset, ckpt_path=ckpt_path)
 
 
 # CLI entrypoint
@@ -82,6 +97,48 @@ def train(config: TrainingConfig) -> None:
             # copy hydra config state and pass to remote execution
             singleton_state = Singleton.get_state()
             remote_fn.remote(config, singleton_state, args=sys.argv)
+
+
+@hydra.main(version_base=None, config_name="config")
+@resume_cli.command()
+def resume(
+    artifact_name: str = typer.Argument(
+        help="Name of the wandb artifact to resume training from (e.g. 'user/project/model:v0')"
+    ),
+    hydra_config_overrides: list[str] = typer.Argument(  # noqa: B008
+        None,
+        help="Optional list of Hydra overrides to update the configuration from the initial training run.",
+    ),
+) -> None:
+    api = wandb.Api()
+    logger.info(f"Querying wandb for artifact {artifact_name}")
+    model_checkpoint = api.artifact(artifact_name)
+    run = model_checkpoint.logged_by()
+    if run:
+        original_run_config = OmegaConf.create(run.config)
+        logger.info(f"Original run config: {original_run_config}\n")
+
+        # initialize hydra config module and config store
+        initialize_config_module(config_module="midi_lm.config", version_base=None)
+        cs = ConfigStore.instance()
+        # insert the original run config into the config store
+        cs.store(name="_config", node=original_run_config)
+        # apply the overrides to the original run config
+        # return the hydra config to update the global state
+        resume_config = compose(
+            config_name="_config",
+            overrides=hydra_config_overrides,
+            return_hydra_config=True,
+        )
+        # update the global state to mirror the logic in the hydra main function
+        # https://github.com/facebookresearch/hydra/issues/2017#issuecomment-1254220345
+        HydraConfig.instance().set_config(resume_config)
+
+        resume_config.resume_from_checkpoint = artifact_name
+        logger.info(f"Resuming training with config: {resume_config}\n")
+        train(resume_config)
+    else:
+        raise ValueError(f"Could not find run for artifact {artifact_name}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ packages = ["midi_lm"]
 
 [project.scripts]
 train = "midi_lm.train:train"
+resume = "midi_lm.train:resume_cli"
 
 [tool.ruff]
 line-length = 108


### PR DESCRIPTION
Add the ability to resume training from a checkpoint saved to Weights and Biases. There's two main ways that we can resume training:
- **weights only**: initialize with the weights from a checkpoint, but initialize everything else from scratch. This means the trainer state will start at `epoch=0` and `global_step=0`, the optimizer and learning rate schedules will be initialized based on the provided config, etc.
- **full state**: begin training from the _exact_ state at the time of checkpoint, picking up where we left off with respect to the trainer `epoch` and `global_step`, resuming the checkpointed learning rate scheduler, etc.

By default, we'll resume with the full state.
```
resume user/project/model:tag -- trainer.max_epochs=20 dataset.batch_size=32
```

If you want to resume with weights only, you can pass a `--clean` flag.
```
resume user/project/model:tag --clean -- trainer.max_epochs=20 dataset.batch_size=32
```
---
**Note**:
It would be nice to be able to support a mode where we can resume from the check-pointed weights and trainer state while reseting things like the learning rate schedule, but PyTorch Lightning doesn't currently make that easy to do. We can either [initialize a model from a checkpoint and optionally override certain config values](https://lightning.ai/docs/pytorch/stable/common/checkpointing_basic.html#initialize-with-other-parameters):
```
model = LightningModule.load_from_checkpoint(checkpoint_path, intial_lr=1e-4)
```
or we can [use the entire checkpoint file](https://lightning.ai/docs/pytorch/stable/common/checkpointing_basic.html#resume-training-state) (resuming all states) when making the call to `Trainer.fit`
```
trainer.fit(model=model, datamodule=dataset, ckpt_path=checkpoint_path)
```