### PR TITLE
Speed up CI jobs with uv for installing Python dependencies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,11 +18,11 @@ jobs:
         cache: "pip"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        python -m pip install uv>=0.1.12
+        uv pip install --system -r requirements-dev.txt
     - name: Install library
       run: |
-        pip install -e .
+        uv pip install --system -e .
     - name: Lint with ruff
       run: |
         ruff .


### PR DESCRIPTION
Setting up the environment and installing dependencies takes the bulk of the CI job, swapping in `uv` seems to reduce job times by ~40%.

_Note: I had been waiting for [this release](https://github.com/astral-sh/uv/releases/tag/0.1.12) so that I could just work with system Python directly instead of having to do a hack with Github Actions. More context in `astral-sh/uv/issues/1526`_ 