### PR TITLE
Add giantmidi piano dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,16 @@ I've added multiple different MIDI datasets of varying complexity (from basic sc
 with networks of varying capacity so I can do some exploration of ideas at a small scale before ramping up the compute
 cost to train larger models on bigger datasets.
 
-| Dataset      | Description                                                         | Train (file count)  | Validation (file count)  |
-|--------------|---------------------------------------------------------------------|---------------------|--------------------------|
-| Eighth Notes | One measure of eighth notes for 12 different pitches                | 6                   | 6                        |
-| Scales       | 12 major and 12 minor scales                                        | 20                  | 4                        |
-| JSB Chorales | A collection of 382 four-part chorales by Johann Sebastian Bach     | 229                 | 76                       |
-| NES          | Songs from the soundtracks of 397 NES games                         | 4441*               | 395*                     |
-| MAESTRO      | MIDI recordings from ten years of International Piano-e-Competition | 962                 | 137                      |
-| SymphonyNet  | A collection of classical and contemporary symphonic compositions   | 37088               | 9272                     |
+| Dataset         | Description                                                         | Train (file count) | Validation (file count) |
+|-----------------|---------------------------------------------------------------------|--------------------|-------------------------|
+| Eighth Notes    | One measure of eighth notes for 12 different pitches                | 6                  | 6                       |
+| Scales          | 12 major and 12 minor scales                                        | 20                 | 4                       |
+| JSB Chorales    | A collection of 382 four-part chorales by Johann Sebastian Bach     | 229                | 76                      |
+| NES             | Songs from the soundtracks of 397 NES games                         | 4441*              | 395*                    |
+| MAESTRO         | MIDI recordings from ten years of International Piano-e-Competition | 962                | 137                     |
+| SymphonyNet     | A collection of classical and contemporary symphonic compositions   | 37088              | 9272                    |
+| GiantMIDI Piano | A classical piano MIDI dataset of 2,786 different composers         | 8682*              | 2170*                   |
+
 
 *Count after filtering out files from the original dataset which don't meet data quality thresholds for a minimum number
 of beats, tracks, etc.
@@ -146,7 +148,7 @@ Compose your configuration from those groups (group=option)
 
 collator: multi-seq-dict
 compute: a100, a10g, cpu, local
-dataset: bach, maestro, nes, scales, symphony-net
+dataset: bach, giantmidi, maestro, nes, scales, symphony-net
 logger: tensorboard, wandb, wandb-test
 lr_scheduler: cosine, plateau
 model: mmt, multihead-transformer, structured

--- a/midi_lm/config/__init__.py
+++ b/midi_lm/config/__init__.py
@@ -67,6 +67,7 @@ config.store(group="dataset", name="bach", node=datasets.BachChoralesDatasetConf
 config.store(group="dataset", name="nes", node=datasets.NESDatasetConfig)
 config.store(group="dataset", name="maestro", node=datasets.MaestroDatasetConfig)
 config.store(group="dataset", name="symphony-net", node=datasets.SymphonyNetConfig)
+config.store(group="dataset", name="giantmidi", node=datasets.GiantMidiDatasetConfig)
 
 config.store(group="logger", name="tensorboard", node=loggers.TensorBoardLoggerConfig)
 config.store(group="logger", name="wandb", node=loggers.WeightsAndBiasesLoggerConfig)

--- a/midi_lm/config/datasets.py
+++ b/midi_lm/config/datasets.py
@@ -39,3 +39,11 @@ class SymphonyNetConfig:
     dataset_dir: str = "data/symphony_net/"
     batch_size: int = 64
     num_workers: int = 16
+
+
+@dataclass
+class GiantMidiDatasetConfig:
+    _target_: str = "midi_lm.datasets.giantmidi_piano.GiantMidiPianoDataModule"
+    dataset_dir: str = "data/giantmidi_piano/"
+    batch_size: int = 64
+    num_workers: int = 16

--- a/midi_lm/datasets/giantmidi_piano.py
+++ b/midi_lm/datasets/giantmidi_piano.py
@@ -1,0 +1,63 @@
+"""
+Download and preprocess this dataset with:
+
+```
+python midi_lm/datasets/giantmidi_piano.py download
+python midi_lm/datasets/giantmidi_piano.py split
+```
+"""
+
+import zipfile
+from pathlib import Path
+
+from midi_lm import logger
+from midi_lm.datasets import download_google_drive_file, verify_download_hash
+from midi_lm.datasets.base import MusicDataModule, MusicDataset
+
+GDRIVE_FILE_ID = "1BDEPaEWFEB2ADquS1VYp5iLZYVngw799"
+DATASET_MD5 = "aaece5750b0cfe30b6a3be5c7bb14f83"
+
+
+class GiantMidiPianoDataset(MusicDataset):
+    name = "GiantMIDI Piano"
+    author = "Qiuqiang Kong, Bochen Li, Jitong Chen, and Yuxuan Wang"
+    source = "https://github.com/bytedance/GiantMIDI-Piano"
+    extension = ".mid"
+
+    @classmethod
+    def download(cls, output_dir: str | Path):
+        # check if file exists
+        zip_file = Path(output_dir) / "midis_v1.2.zip"
+        if zip_file.exists():
+            logger.info(f"Found {zip_file}, skipping download...")
+            # check file hash to ensure it's the correct file
+            verify_download_hash(zip_file, expected_hash=DATASET_MD5)
+        else:
+            logger.info(f"Downloading {cls.name} dataset...")
+            zip_file.parent.mkdir(parents=True, exist_ok=True)
+            download_google_drive_file(GDRIVE_FILE_ID, zip_file.as_posix())
+        with zipfile.ZipFile(zip_file) as zip:
+            logger.info(f"Extracting {zip_file}...")
+            zip.extractall(zip_file.parent)
+
+
+class GiantMidiPianoDataModule(MusicDataModule):
+    dataset_class = GiantMidiPianoDataset
+
+
+if __name__ == "__main__":
+    import typer
+
+    app = typer.Typer()
+
+    @app.command()
+    def download(output_dir: str = "data/giantmidi_piano"):
+        print("Downloading dataset...")
+        GiantMidiPianoDataset.download(output_dir)
+
+    @app.command()
+    def split(dataset_dir: str = "data/giantmidi_piano", preprocess: bool = True):
+        print("Making train/validation splits based on the available MIDI files...")
+        GiantMidiPianoDataset.make_splits(dataset_dir=dataset_dir, preprocess=preprocess)
+
+    app()

--- a/midi_lm/modal_config.py
+++ b/midi_lm/modal_config.py
@@ -104,6 +104,7 @@ def download_scales():
     from midi_lm.datasets.scales import ScalesDataset
 
     ScalesDataset.download("/root/data/scales")
+    volume.commit()
     ScalesDataset.make_splits("/root/data/scales")
     volume.commit()
 
@@ -116,6 +117,7 @@ def download_bach():
     from midi_lm.datasets.bach_chorales import BachChoralesDataset
 
     BachChoralesDataset.download("/root/data/bach_chorales")
+    volume.commit()
     BachChoralesDataset.make_splits("/root/data/bach_chorales")
     volume.commit()
 
@@ -128,6 +130,7 @@ def download_nes():
     from midi_lm.datasets.nes import NESDataset
 
     NESDataset.download("/root/data/nes")
+    volume.commit()
     NESDataset.make_splits("/root/data/nes")
     volume.commit()
 
@@ -140,6 +143,7 @@ def download_maestro():
     from midi_lm.datasets.maestro import MaestroDataset
 
     MaestroDataset.download("/root/data/maestro")
+    volume.commit()
     MaestroDataset.make_splits("/root/data/maestro")
     volume.commit()
 
@@ -152,5 +156,19 @@ def download_symphony_net():
     from midi_lm.datasets.symphony_net import SymphonyNetDataset
 
     SymphonyNetDataset.download("/root/data/symphony_net")
+    volume.commit()
     SymphonyNetDataset.make_splits("/root/data/symphony_net")
+    volume.commit()
+
+
+@stub.function(volumes={"/root/data": volume}, cpu=16, timeout=60 * 60)
+def download_giantmidi():
+    """
+    modal run midi_lm/modal_config.py::stub.download_giantmidi
+    """
+    from midi_lm.datasets.giantmidi_piano import GiantMidiPianoDataset
+
+    GiantMidiPianoDataset.download("/root/data/giantmidi_piano")
+    volume.commit()
+    GiantMidiPianoDataset.make_splits("/root/data/giantmidi_piano")
     volume.commit()


### PR DESCRIPTION
Introduce a larger single-track (piano) dataset from Bytedance comprised of 10,855 MIDI files by 2,786 composers. Similar to the Maestro dataset, they take recordings of professional pianists and generate a MIDI representation from the audio recording.

https://github.com/bytedance/GiantMIDI-Piano/

Verified models can train on the new dataset: https://wandb.ai/jeremytjordan/midi-language-modeling/runs/9lphs357/workspace?workspace=user-jeremytjordan