### PR TITLE
Improve MIDI visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,12 @@ Example local runs:
 train compute=local logger=wandb-test trainer=mps \
     tokenizer=mmt model=mmt network=mmt-1m \
     dataset=scales transforms=crop \
-    trainer.val_check_interval=1.0 trainer.max_epochs=20
+    trainer.max_epochs=20
 ```
 ```
 train compute=local logger=wandb-test trainer=mps \
     tokenizer=mmt model=mmt network=mmt-1m \
-    dataset=bach transforms=crop_transpose \
-    trainer.val_check_interval=1.0
+    dataset=bach transforms=crop_transpose
 ```
 ```
 train compute=local logger=wandb-test trainer=mps \
@@ -120,11 +119,12 @@ train compute=local logger=wandb-test trainer=mps \
 
 Example remote run:
 ```
-train compute=a10g compute.timeout=21600 logger=wandb trainer=gpu \
+train compute=a10g logger=wandb trainer=gpu \
     tokenizer=mmt model=mmt network=mmt-7m \
     dataset=maestro transforms=crop-transpose
-
-train compute=a10g compute.timeout=3600 logger=wandb-test trainer=gpu \
+```
+```
+train compute=a10g logger=wandb-test trainer=gpu \
     tokenizer=mmt model=mmt network=mmt-7m \
     dataset=nes transforms=crop-transpose \
     +trainer.profiler="simple" +trainer.max_steps=10
@@ -147,7 +147,7 @@ below for convenience.
 Compose your configuration from those groups (group=option)
 
 collator: multi-seq-dict
-compute: a100, a10g, cpu, local
+compute: a100, a10g, cpu, h100, local
 dataset: bach, giantmidi, maestro, nes, scales, symphony-net
 logger: tensorboard, wandb, wandb-test
 lr_scheduler: cosine, plateau

--- a/midi_lm/visualizations/animated_pianoroll.py
+++ b/midi_lm/visualizations/animated_pianoroll.py
@@ -106,8 +106,12 @@ def midi_player_iframe(
     </style>
     <script src="{MAGENTA_JS}"></script>
     <p>{title}</p>
-    <midi-player src="{data_url}" sound-font visualizer="#midi-visualizer"></midi-player>
-    <midi-visualizer type="{vis_type}" id="midi-visualizer" style="background: #fff;"></midi-visualizer>
+    <section>
+      <midi-player src="{data_url}" sound-font="" visualizer="#midi-visualizer">
+      </midi-player>
+      <midi-visualizer src="{data_url}" type="{vis_type}" id="midi-visualizer">
+      </midi-visualizer>
+    </section>
     """
 
     output = f"""


### PR DESCRIPTION
Make the MIDI visualization visible by default.

Before:
![Screenshot 2024-03-06 at 10 55 50 PM](https://github.com/jeremyjordan/midi-lm/assets/13970565/168aefe7-2114-46b6-9bfb-d24c4fbedf6d)
(previously you would need to click play, and then the MIDI track would appear)

After:
![Screenshot 2024-03-06 at 10 54 12 PM](https://github.com/jeremyjordan/midi-lm/assets/13970565/7d2a3886-935e-46bc-afde-148da47da763)
